### PR TITLE
Honor zero retry overrides in client config

### DIFF
--- a/controllers/internal/clients/types.go
+++ b/controllers/internal/clients/types.go
@@ -121,9 +121,6 @@ func (cfg FactoryConfig) ApplyDefaults() FactoryConfig {
 	if cfg.MaxRetries < 0 {
 		cfg.MaxRetries = defaultRetries
 	}
-	if cfg.MaxRetries == 0 {
-		cfg.MaxRetries = defaultRetries
-	}
 	if cfg.RetryInitialBackoff <= 0 {
 		cfg.RetryInitialBackoff = 200 * time.Millisecond
 	}

--- a/controllers/internal/clients/types_test.go
+++ b/controllers/internal/clients/types_test.go
@@ -1,0 +1,23 @@
+package clients
+
+import "testing"
+
+func TestFactoryConfig_ApplyDefaultsRespectsZeroRetries(t *testing.T) {
+	cfg := FactoryConfig{MaxRetries: 0}
+
+	normalized := cfg.ApplyDefaults()
+
+	if normalized.MaxRetries != 0 {
+		t.Fatalf("MaxRetries: got %d, want 0", normalized.MaxRetries)
+	}
+}
+
+func TestFactoryConfig_ApplyDefaultsNegativeRetriesUsesDefault(t *testing.T) {
+	cfg := FactoryConfig{MaxRetries: -1}
+
+	normalized := cfg.ApplyDefaults()
+
+	if normalized.MaxRetries <= 0 {
+		t.Fatalf("MaxRetries: got %d, want positive default", normalized.MaxRetries)
+	}
+}


### PR DESCRIPTION
## Summary
- keep MaxRetries overrides of zero when normalizing client factory configuration
- add unit coverage to ensure zero retries are preserved and negative values reset to defaults

## Testing
- go test ./controllers/internal/clients -count=1 *(hangs in environment; had to interrupt)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942f128279c8328bcbd34c83f1f679f)